### PR TITLE
Feature gate the `type_name` function

### DIFF
--- a/anymore/Cargo.toml
+++ b/anymore/Cargo.toml
@@ -17,9 +17,9 @@ targets = []
 
 [features]
 default = ["alloc", "type_name"]
-# Include helper implementation of downcasting from a Box.
+# Include helper implementation of downcasting from a `Box`.
 alloc = []
-# Include the type_name function on AnyDebug, which is useful for debugging downcasting.
+# Include the `AnyDebug::type_name` method, which is useful for debugging downcasting.
 type_name = []
 
 [dependencies]

--- a/anymore/Cargo.toml
+++ b/anymore/Cargo.toml
@@ -16,9 +16,11 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [features]
-default = ["alloc"]
-# Include implementations of downcasting from a Box
+default = ["alloc", "type_name"]
+# Include helper implementation of downcasting from a Box.
 alloc = []
+# Include the type_name function on AnyDebug, which is useful for debugging downcasting.
+type_name = []
 
 [dependencies]
 

--- a/anymore/README.md
+++ b/anymore/README.md
@@ -73,6 +73,9 @@ co-developed with Xilem.
 ## Features
 
 - `alloc` (enabled by default): Implement downcasting from [`Box`]es.
+  If this feature is not enabled, Anymore can be used in contexts without an allocator enabled.
+- `type_name` (enabled by default): Provide the `type_name` function on `AnyDebug`, which gives the type's name.
+  Most users should leave this enabled, as the costs of this method existing are expected to be negligible.
 
 <!-- cargo-rdme end -->
 

--- a/anymore/README.md
+++ b/anymore/README.md
@@ -70,7 +70,9 @@ Because of this, Xilem uses the `AnyDebug` trait for these messages, so they can
 A similar need arises in [Masonry](https://docs.rs/masonry/latest/masonry/), which is the widget toolkit
 co-developed with Xilem.
 
-## Features
+## Feature Flags
+
+The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) are available:
 
 - `alloc` (enabled by default): Implement downcasting from [`Box`]es.
   If this feature is not enabled, Anymore can be used in contexts without an allocator enabled.

--- a/anymore/src/lib.rs
+++ b/anymore/src/lib.rs
@@ -41,7 +41,9 @@
 //! A similar need arises in [Masonry](https://docs.rs/masonry/latest/masonry/), which is the widget toolkit
 //! co-developed with Xilem.
 //!
-//! ## Features
+//! ## Feature Flags
+//!
+//! The following crate [feature flags](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) are available:
 //!
 //! - `alloc` (enabled by default): Implement downcasting from [`Box`]es.
 //!   If this feature is not enabled, Anymore can be used in contexts without an allocator enabled.

--- a/anymore/src/lib.rs
+++ b/anymore/src/lib.rs
@@ -231,6 +231,7 @@ mod tests {
     struct SomeMessage(u32);
 
     #[test]
+    #[cfg(feature = "type_name")]
     fn any_debug_correct_typename() {
         let val = SomeMessage(4);
         let val: &dyn AnyDebug = &val;


### PR DESCRIPTION
As discussed in #1, this is probably overly cautious. However, the costs on our side is extremely low, and the cost of a breaking release is sufficiently high, that I believe this feature gate is worth having.

To clarify why someone could want to disable this feature - in certain cases (especially on the web), binary size is extremely important. If the optimiser/linker doesn't notice that this function is never used (which is especially likely given that this type is used for `dyn` values), each vtable for `dyn AnyDebug` will need an implementation of this. These implementations individually don't have a huge cost; a single function and a (relatively) short string. However, we expect there to be quite a few of these (probably about 1 per widget, for example).